### PR TITLE
Add support for Hero4/Hero Session, Hero5 and Hero6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.pio
+.pioenvs
+.piolibdeps
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+platformio.ini

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"platformio.platformio-ide"
+	]
+}

--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # GoProControl
 This is a library to interface with GoPro camera
 
-Supported boards:
+## Supported boards/camera:
 - ESP8266 or ESP32
 - any arduino boards (UNO, nano, 101, etc.) attached to an ESP8266 (ESP01) using this library https://github.com/bportaluri/WiFiEsp
+
+For now I just added my camera (HERO3+) but I made the library with a style which would be quite easy to add other cameras. I will be very happy to accept pull requests and have as collaborator other people
+
+## Installation
+
+Use the arduino library manager
+
+## Reference
 
 for more information see here: https://www.hackster.io/vincenzo-g/goprocontrol-arduino-9083e2
 
 all the commands came from: https://github.com/KonradIT/goprowifihack
-
-For now I just added my camera (HERO3+) but I made the library with a style which would be quite easy to add other cameras. I will be very happy to accept pull requests and have as collaborator other people
-
 
 The idea cames from another gopro library: https://github.com/agdl/GoPRO which works only on arduino WiFi boards and only with gopro HERO3.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ I made the library with a style which would be quite easy to add other cameras (
 Use the arduino library manager or download directly from github
 
 # Story
-Have you ever thought about the possibility to control your action camera with your Arduino? Well if you are here because you googled that here you may be interested in watching [this video](https://youtu.be/PuM-ZQ2tMW0)
+Have you ever thought about the possibility to control your action camera with your Arduino? Well if you are here because you googled that here you may be interested in watching this video
 
-[![Alt text](https://img.youtube.com/vi/PuM-ZQ2tMW0/0.jpg)](https://www.youtube.com/watch?v=PuM-ZQ2tMW0 "click to watch it on youtube")
+[![Alt text](https://img.youtube.com/vi/PuM-ZQ2tMW0/0.jpg)](https://www.youtube.com/watch?v=PuM-ZQ2tMW0)
+
+click to watch it on youtube
 
 In the video I take a picture, change the mode from photo to video, start and stop a video, I delete a file and finally I turn off the GoPro. But these are only a few of the functions that are possible to do with this library. For example you could change the FOV (field of view), the frame rate, the photo and video resolution, turn the localization on or off, rotate the orientation of the camera and more
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,31 @@
-# GoProControl
-This is a library to interface with GoPro camera
+# GoPro Control Arduino
+This is a library to interface with GoPro cameras, just press a button and turn on your GoPro action camera using an Arduino!
 
-## Supported boards/camera:
-- ESP8266 or ESP32
-- any arduino boards (UNO, nano, 101, etc.) attached to an ESP8266 (ESP01) using this library https://github.com/bportaluri/WiFiEsp
+![gopro and arduino](https://mega.nz/#!kKA10SyC!xneQqS0coYkKzBZopp3TtVHcCYmYVRG_IKMqsk8P_B0)
 
-For now I just added my camera (HERO3+) but I made the library with a style which would be quite easy to add other cameras. I will be very happy to accept pull requests and have as collaborator other people
+## Supported boards:
+- ESP8266
+- ESP32
+- any arduino boards (UNO, nano, 101, etc.) attached to an ESP8266 (ESP01) using [this library](https://github.com/bportaluri/WiFiEsp)
+
+## Supported cameras:
+- HERO3+
+
+I made the library with a style which would be quite easy to add other cameras (not only gopro). I will be very happy to accept pull requests and have as collaborator other people
 
 ## Installation
 
-Use the arduino library manager
+Use the arduino library manager or download directly from github
+
+# Story
+Have you ever thought about the possibility to control your action camera with your Arduino? Well if you are here because you googled that here you may be interested in watching [this video](https://youtu.be/PuM-ZQ2tMW0)
+
+[![Alt text](https://img.youtube.com/vi/PuM-ZQ2tMW0&feature=youtu.be/0.jpg)](https://www.youtube.com/watch?v=PuM-ZQ2tMW0&feature=youtu.be)
+
+
+In the video I take a picture, change the mode from photo to video, start and stop a video, I delete a file and finally I turn off the GoPro. But these are only a few of the functions that are possible to do with this library. For example you could change the FOV (field of view), the frame rate, the photo and video resolution, turn the localization on or off, rotate the orientation of the camera and more
 
 ## Reference
-
-for more information see here: https://www.hackster.io/vincenzo-g/goprocontrol-arduino-9083e2
 
 all the commands came from: https://github.com/KonradIT/goprowifihack
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GoPro Control Arduino
 This is a library to interface with GoPro cameras, just press a button and turn on your GoPro action camera using an Arduino!
 
-![gopro and arduino](https://mega.nz/#!kKA10SyC!xneQqS0coYkKzBZopp3TtVHcCYmYVRG_IKMqsk8P_B0)
+![gopro and arduino](https://image.ibb.co/cGRb4p/1.jpg)
 
 ## Supported boards:
 - ESP8266
@@ -20,8 +20,7 @@ Use the arduino library manager or download directly from github
 # Story
 Have you ever thought about the possibility to control your action camera with your Arduino? Well if you are here because you googled that here you may be interested in watching [this video](https://youtu.be/PuM-ZQ2tMW0)
 
-[![Alt text](https://img.youtube.com/vi/PuM-ZQ2tMW0&feature=youtu.be/0.jpg)](https://www.youtube.com/watch?v=PuM-ZQ2tMW0&feature=youtu.be)
-
+[![Alt text](https://img.youtube.com/vi/PuM-ZQ2tMW0/0.jpg)](https://www.youtube.com/watch?v=PuM-ZQ2tMW0 "click to watch it on youtube")
 
 In the video I take a picture, change the mode from photo to video, start and stop a video, I delete a file and finally I turn off the GoPro. But these are only a few of the functions that are possible to do with this library. For example you could change the FOV (field of view), the frame rate, the photo and video resolution, turn the localization on or off, rotate the orientation of the camera and more
 

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=A library that makes using GoPro a breeze.
 paragraph=soon more cameras.
 category=Smart device
 url=https://github.com/aster94/GoProControl/
-architectures=all
+architectures=*

--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=GoProControl
-version=0.9.0
-author=Vincenzo G.
-maintainer=Vincenzo G.
+version=0.9.1
+author=Vincenzo G. / KonradIT
+maintainer=Vincenzo G. / KonradIT
 sentence=A library that makes using GoPro a breeze.
 paragraph=soon more cameras.
 category=Device Control

--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Vincenzo G.
 maintainer=Vincenzo G.
 sentence=A library that makes using GoPro a breeze.
 paragraph=soon more cameras.
-category=Smart device
+category=Device Control
 url=https://github.com/aster94/GoProControl/
 architectures=*

--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,9 @@
 name=GoProControl
 version=0.9.0
 author=Vincenzo G.
+maintainer=Vincenzo G.
 sentence=A library that makes using GoPro a breeze.
+paragraph=soon more cameras.
 category=Smart device
 url=https://github.com/aster94/GoProControl/
 architectures=all

--- a/src/GoProControl.cpp
+++ b/src/GoProControl.cpp
@@ -34,12 +34,14 @@ GoProControl::GoProControl(String ssid, String pwd, uint8_t camera){
 			
 		url = "http://" + _host + "/camera/";
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {	//HERO4 + 5 + 6:
+		//URL scheme: http://HOST/gp/gpControl/....
+		//Basic functions (record, mode, tag, poweroff): http://HOST/gp/gpControl/command/PARAM?p=OPTION (eg: change mode to video http://10.5.5.9/gp/gpControl/command/mode?p=0)
+		//Settings: http://HOST/gp/gpControl/setting/SETTING/option (eg: change video resolution to 1080p: http://10.5.5.9/gp/gpControl/setting/2/9)
+		
+		_host = "10.5.5.9";
+		_port = 80;
+		url = "http://" + _host + "/gp/gpControl/";
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -189,12 +191,9 @@ uint8_t GoProControl::turnOn(void){
 		
 		requestURL = url + "PW?t=" + _pwd + "&p=%01";
 		
-	} else if (_camera == 4) {	//HERO4
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
 		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+		//send Wake-On-LAN command
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -213,12 +212,10 @@ uint8_t GoProControl::turnOff(void){
 		
 		requestURL = url + "PW?t=" + _pwd + "&p=%00";
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	
+		requestUrl = url + "command/system/sleep";
+	
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -237,12 +234,10 @@ uint8_t GoProControl::localizationOn(void){
 		
 		requestURL = url + "LL?t=" + _pwd + "&p=%01";
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	
+		requestUrl = url + "command/system/locate?p=1";
+	
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -261,12 +256,10 @@ uint8_t GoProControl::localizationOff(void){
 		
 		requestURL = url + "LL?t=" + _pwd + "&p=%00";
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	
+		requestUrl = url + "command/system/locate?p=0";
+	
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -285,12 +278,10 @@ uint8_t GoProControl::startCapture(void){
 		
 		requestURL = url + "SH?t=" + _pwd + "&p=%01";
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	
+		requestUrl = url + "command/shutter?p=1";
+	
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -309,12 +300,8 @@ uint8_t GoProControl::stopCapture(void){
 		
 		requestURL = url + "SH?t=" + _pwd + "&p=%00";
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+		requestUrl = url + "command/shutter?p=0";
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -333,12 +320,8 @@ uint8_t GoProControl::deleteLast(void){
 		
 		requestURL = url + "DL?t=" + _pwd;
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+		requestUrl = url + "command/storage/delete/last";
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -357,12 +340,8 @@ uint8_t GoProControl::deleteAll(void){
 		
 		requestURL = url + "DA?t=" + _pwd;
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+		requestUrl = url + "command/command/storage/delete/all";
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -394,12 +373,13 @@ uint8_t GoProControl::setCameraMode(uint8_t option){
 		else if (option == PLAY_HDMI) stringOption = "05";
 		requestURL = url + "CM?t=" + _pwd + "&p=%" + stringOption;
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+		//todo: add sub-modes
+		if(option == VIDEO_MODE) stringOption = "0";
+		else if (option == PHOTO_MODE) stringOption = "1";
+		else if (option == MULTISHOT_MODE) stringOption = "2";
+		requestURL = url + "command/mode?p=" + stringOption
+		
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -422,12 +402,12 @@ uint8_t GoProControl::setCameraOrientation(uint8_t option){
 
 		requestURL = url + "UP?t=" + _pwd + "&p=%" + stringOption;
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+		if(option == ORIENTATION_UP) stringOption = "0";
+		else if (option == ORIENTATION_DOWN) stringOption = "1";
+		else if (option == ORIENTATION_AUTO) stringOption = "2";
+		requestUrl = url + "setting/52/" + stringOption;
+		
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -455,12 +435,19 @@ uint8_t GoProControl::setVideoResolution(uint8_t option){
 
 		requestURL = url + "VR?t=" + _pwd + "&p=%" + stringOption;
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+		if (option == VR_4K) stringOption = "1";
+		else if (option == VR_2K) stringOption = "4"
+		else if (option == VR_2K_SuperView) stringOption = "5";
+		else if (option == VR_1440p) stringOption = "7";
+		else if (option == VR_1080p_SuperView) stringOption = "8";
+		else if (option == VR_1080p) stringOption = "9";
+		else if (option == VR_960p) stringOption = "10";
+		else if (option == VR_720p_SuperView) stringOption = "11";
+		else if (option == VR_720p) stringOption = "12";
+		else if (option == VR_WVGA) stringOption = "13";
+		
+		requestURL = url + "setting/2/" + stringOption;
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -484,12 +471,16 @@ uint8_t GoProControl::setPhotoResolution(uint8_t option){
 
 		requestURL = url + "PR?t=" + _pwd + "&p=%" + stringOption;
 
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+		if (option == PR_12MP_Wide) stringOption = "0";
+		else if (option == PR_12MP_Linear) stringOption = "10";
+		else if (option == PR_12MP_Medium) stringOption = "8";
+		else if (option == PR_12MP_Narrow) stringOption = "9";
+		else if (option == PR_7MP_Wide) stringOption = "1";
+		else if (option == PR_7MP_Medium) stringOption = "2";
+		else if (option == PR_5MP_Wide) stringOption = "3";
+		requestUrl = url + "setting/17/" + stringOption;
+		
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -521,12 +512,18 @@ uint8_t	GoProControl::setFrameRate(uint8_t option){
 		else if (option == FPS240) stringOption = "0a";
 		requestURL = url + "FS?t=" + _pwd + "&p=%" + stringOption;
 
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+		if (option == FR_240) stringOption = "0";
+		else if (option == FR_120) stringOption = "1";
+		else if (option == FR_100) stringOption = "2";
+		else if (option == FR_90) stringOption = "3";
+		else if (option == FR_80) stringOption = "4";
+		else if (option == FR_60) stringOption = "5";
+		else if (option == FR_50) stringOption = "6";
+		else if (option == FR_48) stringOption = "7";
+		else if (option == FR_30) stringOption = "8";
+		else if (option == FR_25) stringOption = "9";
+		requestUrl = url + "setting/3/" + stringOption;
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -549,12 +546,13 @@ uint8_t GoProControl::setFov(uint8_t option){
 		else if (option == NARROW_FOV) stringOption = "02";
 		requestURL = url + "FV?t=" + _pwd + "&p=%" + stringOption;
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+		if (option == WIDE_FOV) stringOption = "0";
+		else if (option == MEDIUM_FOV) stringOption = "1";
+		else if (option == NARROW_FOV) stringOption = "2";
+		else if (option == LINEAR_FOV) stringOption = "4";
+		
+		requestUrl = url + "setting/4/" + stringOption;
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -576,12 +574,10 @@ uint8_t GoProControl::setVideoMode(uint8_t option){
 		else if (option == PAL) stringOption = "01";
 		requestURL = url + "VM?t=" + _pwd + "&p=%" + stringOption;
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+		if(option == NTSC) stringOption = "0";
+		else if (option == PAL) stringOption = "1";
+		requestURL = url + "setting/57/" + stringOption;
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -607,12 +603,15 @@ uint8_t GoProControl::setTimeLapseInterval(float option){
 		else if(option == 60) stringOption = "3c";
 		requestURL = url + "TI?t=" + _pwd + "&p=%" + stringOption;
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
+	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+		if(option == 0.5) stringOption = "0";
+		else if(option == 1) stringOption = "1";
+		else if(option == 2) stringOption = "1";
+		else if(option == 5) stringOption = "3";
+		else if(option == 10) stringOption = "4";
+		else if(option == 30) stringOption = "5";
+		else if(option == 60) stringOption = "6";
+		requestURL = url + "setting/5/" + stringOption;
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -636,15 +635,7 @@ uint8_t GoProControl::setContinuousShot(uint8_t option){
 		else if(option == 10) stringOption = "0a";
 		requestURL = url + "CS?t=" + _pwd + "&p=%" + stringOption;
 		
-	} else if (_camera == 4) {	//HERO4
-		//todo
-	} else if (_camera == 5) {	//HERO5
-		//todo
-	} else if (_camera == 6) {	//HERO6
-		//todo
-	} else if (_camera == 7) {	//next?
-		//future
-	}	
+	} /* Not supported in Hero4/5/6 */
 	
 	return(sendRequest(requestURL));
 }

--- a/src/GoProControl.cpp
+++ b/src/GoProControl.cpp
@@ -34,7 +34,7 @@ GoProControl::GoProControl(String ssid, String pwd, uint8_t camera){
 			
 		url = "http://" + _host + "/camera/";
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {	//HERO4 + 5 + 6:
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {	//HERO4 + 5 + 6:
 		//URL scheme: http://HOST/gp/gpControl/....
 		//Basic functions (record, mode, tag, poweroff): http://HOST/gp/gpControl/command/PARAM?p=OPTION (eg: change mode to video http://10.5.5.9/gp/gpControl/command/mode?p=0)
 		//Settings: http://HOST/gp/gpControl/setting/SETTING/option (eg: change video resolution to 1080p: http://10.5.5.9/gp/gpControl/setting/2/9)
@@ -191,7 +191,7 @@ uint8_t GoProControl::turnOn(void){
 		
 		requestURL = url + "PW?t=" + _pwd + "&p=%01";
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
 		//todo
 		//send Wake-On-LAN command
 	} else if (_camera == 7) {	//next?
@@ -212,9 +212,9 @@ uint8_t GoProControl::turnOff(void){
 		
 		requestURL = url + "PW?t=" + _pwd + "&p=%00";
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
 	
-		requestUrl = url + "command/system/sleep";
+		requestURL = url + "command/system/sleep";
 	
 	} else if (_camera == 7) {	//next?
 		//future
@@ -234,9 +234,9 @@ uint8_t GoProControl::localizationOn(void){
 		
 		requestURL = url + "LL?t=" + _pwd + "&p=%01";
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
 	
-		requestUrl = url + "command/system/locate?p=1";
+		requestURL = url + "command/system/locate?p=1";
 	
 	} else if (_camera == 7) {	//next?
 		//future
@@ -256,9 +256,9 @@ uint8_t GoProControl::localizationOff(void){
 		
 		requestURL = url + "LL?t=" + _pwd + "&p=%00";
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
 	
-		requestUrl = url + "command/system/locate?p=0";
+		requestURL = url + "command/system/locate?p=0";
 	
 	} else if (_camera == 7) {	//next?
 		//future
@@ -278,9 +278,9 @@ uint8_t GoProControl::startCapture(void){
 		
 		requestURL = url + "SH?t=" + _pwd + "&p=%01";
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
 	
-		requestUrl = url + "command/shutter?p=1";
+		requestURL = url + "command/shutter?p=1";
 	
 	} else if (_camera == 7) {	//next?
 		//future
@@ -300,8 +300,8 @@ uint8_t GoProControl::stopCapture(void){
 		
 		requestURL = url + "SH?t=" + _pwd + "&p=%00";
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
-		requestUrl = url + "command/shutter?p=0";
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
+		requestURL = url + "command/shutter?p=0";
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -320,8 +320,8 @@ uint8_t GoProControl::deleteLast(void){
 		
 		requestURL = url + "DL?t=" + _pwd;
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
-		requestUrl = url + "command/storage/delete/last";
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
+		requestURL = url + "command/storage/delete/last";
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -340,8 +340,8 @@ uint8_t GoProControl::deleteAll(void){
 		
 		requestURL = url + "DA?t=" + _pwd;
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
-		requestUrl = url + "command/command/storage/delete/all";
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
+		requestURL = url + "command/command/storage/delete/all";
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -373,12 +373,12 @@ uint8_t GoProControl::setCameraMode(uint8_t option){
 		else if (option == PLAY_HDMI) stringOption = "05";
 		requestURL = url + "CM?t=" + _pwd + "&p=%" + stringOption;
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
 		//todo: add sub-modes
 		if(option == VIDEO_MODE) stringOption = "0";
 		else if (option == PHOTO_MODE) stringOption = "1";
 		else if (option == MULTISHOT_MODE) stringOption = "2";
-		requestURL = url + "command/mode?p=" + stringOption
+		requestURL = url + "command/mode?p=" + stringOption;
 		
 	} else if (_camera == 7) {	//next?
 		//future
@@ -402,11 +402,11 @@ uint8_t GoProControl::setCameraOrientation(uint8_t option){
 
 		requestURL = url + "UP?t=" + _pwd + "&p=%" + stringOption;
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
 		if(option == ORIENTATION_UP) stringOption = "0";
 		else if (option == ORIENTATION_DOWN) stringOption = "1";
 		else if (option == ORIENTATION_AUTO) stringOption = "2";
-		requestUrl = url + "setting/52/" + stringOption;
+		requestURL = url + "setting/52/" + stringOption;
 		
 	} else if (_camera == 7) {	//next?
 		//future
@@ -435,9 +435,9 @@ uint8_t GoProControl::setVideoResolution(uint8_t option){
 
 		requestURL = url + "VR?t=" + _pwd + "&p=%" + stringOption;
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
 		if (option == VR_4K) stringOption = "1";
-		else if (option == VR_2K) stringOption = "4"
+		else if (option == VR_2K) stringOption = "4";
 		else if (option == VR_2K_SuperView) stringOption = "5";
 		else if (option == VR_1440p) stringOption = "7";
 		else if (option == VR_1080p_SuperView) stringOption = "8";
@@ -471,7 +471,7 @@ uint8_t GoProControl::setPhotoResolution(uint8_t option){
 
 		requestURL = url + "PR?t=" + _pwd + "&p=%" + stringOption;
 
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
 		if (option == PR_12MP_Wide) stringOption = "0";
 		else if (option == PR_12MP_Linear) stringOption = "10";
 		else if (option == PR_12MP_Medium) stringOption = "8";
@@ -479,7 +479,7 @@ uint8_t GoProControl::setPhotoResolution(uint8_t option){
 		else if (option == PR_7MP_Wide) stringOption = "1";
 		else if (option == PR_7MP_Medium) stringOption = "2";
 		else if (option == PR_5MP_Wide) stringOption = "3";
-		requestUrl = url + "setting/17/" + stringOption;
+		requestURL = url + "setting/17/" + stringOption;
 		
 	} else if (_camera == 7) {	//next?
 		//future
@@ -512,7 +512,7 @@ uint8_t	GoProControl::setFrameRate(uint8_t option){
 		else if (option == FPS240) stringOption = "0a";
 		requestURL = url + "FS?t=" + _pwd + "&p=%" + stringOption;
 
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
 		if (option == FR_240) stringOption = "0";
 		else if (option == FR_120) stringOption = "1";
 		else if (option == FR_100) stringOption = "2";
@@ -523,7 +523,7 @@ uint8_t	GoProControl::setFrameRate(uint8_t option){
 		else if (option == FR_48) stringOption = "7";
 		else if (option == FR_30) stringOption = "8";
 		else if (option == FR_25) stringOption = "9";
-		requestUrl = url + "setting/3/" + stringOption;
+		requestURL = url + "setting/3/" + stringOption;
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -546,13 +546,13 @@ uint8_t GoProControl::setFov(uint8_t option){
 		else if (option == NARROW_FOV) stringOption = "02";
 		requestURL = url + "FV?t=" + _pwd + "&p=%" + stringOption;
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
 		if (option == WIDE_FOV) stringOption = "0";
 		else if (option == MEDIUM_FOV) stringOption = "1";
 		else if (option == NARROW_FOV) stringOption = "2";
 		else if (option == LINEAR_FOV) stringOption = "4";
 		
-		requestUrl = url + "setting/4/" + stringOption;
+		requestURL = url + "setting/4/" + stringOption;
 	} else if (_camera == 7) {	//next?
 		//future
 	}	
@@ -574,7 +574,7 @@ uint8_t GoProControl::setVideoMode(uint8_t option){
 		else if (option == PAL) stringOption = "01";
 		requestURL = url + "VM?t=" + _pwd + "&p=%" + stringOption;
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
 		if(option == NTSC) stringOption = "0";
 		else if (option == PAL) stringOption = "1";
 		requestURL = url + "setting/57/" + stringOption;
@@ -603,7 +603,7 @@ uint8_t GoProControl::setTimeLapseInterval(float option){
 		else if(option == 60) stringOption = "3c";
 		requestURL = url + "TI?t=" + _pwd + "&p=%" + stringOption;
 		
-	} else if (_camera == 4 || _camera = 5 || _camera = 6) {
+	} else if (_camera == 4 || _camera == 5 || _camera == 6) {
 		if(option == 0.5) stringOption = "0";
 		else if(option == 1) stringOption = "1";
 		else if(option == 2) stringOption = "1";

--- a/src/GoProControl.h
+++ b/src/GoProControl.h
@@ -43,9 +43,13 @@
 #define TIMER_MODE 4
 #define PLAY_HDMI 5
 
+//Hero4/5/6 modes:
+#define MULTISHOT_MODE 2
+
 /*Orientation*/
 #define ORIENTATION_UP 0
 #define ORIENTATION_DOWN 1
+#define ORIENTATION_AUTO 2 /*Hero4/5/6*/
 
 /*Resolutions*/
 #define VR_WVGA60 0
@@ -55,6 +59,19 @@
 #define VR_960_30 4
 #define VR_960_48 5
 #define VR_1080_30 6
+
+/*Resolutions Hero4/5/6*/
+
+#define VR_4K 1
+#define VR_2K 4
+#define VR_2K_SuperView 5
+#define VR_1440p 7
+#define VR_1080p_SuperView 8
+#define VR_1080p 9
+#define VR_960p 10
+#define VR_720p_SuperView 11
+#define VR_720p 12
+#define VR_WVGA 13
 
 /*Frame Rates*/
 #define FPS12 0
@@ -70,10 +87,24 @@
 #define FPS120 10
 #define FPS240 11
 
+/* Frame rates Hero4/5/6*/
+
+#define FR_240 0
+#define FR_120 1
+#define FR_100 2
+#define FR_90 3
+#define FR_80 4
+#define FR_60 5
+#define FR_50 6
+#define FR_48 7
+#define FR_30 8
+#define FR_25 9
+
 /*FOV*/
 #define WIDE_FOV 0
 #define MEDIUM_FOV 1
 #define NARROW_FOV 2
+#define LINEAR_FOV 4 /* Hero4/5/6 */
 
 /*Photo Resolutions*/
 #define PR_12mpW 0
@@ -82,6 +113,15 @@
 #define PR_7mpW 3
 #define PR_5mpW 4
 
+/* Photo Resolution Hero 4/5/6 */
+
+#define PR_12MP_Wide 0
+#define PR_12MP_Linear 10
+#define PR_12MP_Medium 8
+#define PR_12MP_Narrow 9
+#define PR_7MP_Wide 1
+#define PR_7MP_Medium 2
+#define PR_5MP_Wide 3
 
 class GoProControl{
 	


### PR DESCRIPTION
Hola :wave: 

I've added the necessary calls for the newer GoPro cameras. Hero4 (Black/Silver/Session), Hero5 (Black/Session), Hero6 (Black) react to the same commands. There are differences with framerates and photo resolutions.

Code is untested, I've ordered a NodeMCU (mine is called "D1 mini - Mini NodeMcu 4M Lua WIFI IOT development board based ESP8266") which should arrive in 5 days.