### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Control your GoPro HERO3, HERO4, HERO5, HERO6, HERO7, FUSION from Ardu
 category=Device Control
 url=https://github.com/aster94/GoProControl/
 architectures=*
+depends=WiFi101, WiFiNINA, VidorPeripherals, WiFiEsp


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format